### PR TITLE
feat: fault tolerance on start

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,10 +6,46 @@ const Logger = require('./lib/utils/logger');
 
 const logger = new Logger('bbb-pads');
 
-api.call('checkToken').then(() => {
-  subscriber.start();
-  server.start();
-  monitor.start();
-}).catch(() => {
-  logger.fatal('api key', 'mismatch');
-});
+const RETRY = 10;
+
+let retries = 0;
+
+const fibonacci = (index) => {
+  if (index === 1) return 0;
+
+  if (index === 2) return 1;
+
+  return fibonacci(index - 1) + fibonacci(index - 2);
+};
+
+const abort = (error) => {
+  logger.fatal('abort', error);
+
+  process.exit(1);
+};
+
+const start = () => {
+  api.check().then(() => {
+    api.call('checkToken').then(() => {
+      subscriber.start();
+      server.start();
+      monitor.start();
+    }).catch(() => abort('key-mismatch'));
+  }).catch((error) => {
+    logger.warn('starting', error);
+
+    if (retries < RETRY) {
+      retries++;
+
+      setTimeout(() => {
+        logger.info('start', `retry ${retries} of ${RETRY}`);
+
+        start();
+      }, 1000 * fibonacci(retries));
+    } else {
+      abort('retry-exhausted');
+    }
+  });
+};
+
+start();

--- a/lib/etherpad/api.js
+++ b/lib/etherpad/api.js
@@ -7,7 +7,9 @@ const logger = new Logger('api');
 
 const { etherpad: settings } = config;
 
-const url = `${settings.scheme}://${settings.host}:${settings.port}/api/${settings.api.version}`;
+const baseURL = `${settings.scheme}://${settings.host}:${settings.port}/api`;
+
+const url = `${baseURL}/${settings.api.version}`;
 
 const buildURL = (method, params) => {
   let query = `apikey=${settings.api.key}`;
@@ -53,6 +55,15 @@ const call = (method, params = {}) => {
   });
 };
 
+const check = () => {
+  return axios({
+    method: 'get',
+    url: baseURL,
+    responseType: 'json'
+  });
+};
+
 module.exports = {
   call,
+  check,
 };


### PR DESCRIPTION
Check if Etherpad HTTP's API is running before validating the configured
API key.

The module will retry up to 10 times (following fibonacci tempered intervals)
to check if Etherpad's API is up and running. This should mitigate the case
where both bbb-pads and etherpad's services are starting.