### PR TITLE
feat(api): call lock

### DIFF
--- a/lib/etherpad/api.js
+++ b/lib/etherpad/api.js
@@ -1,5 +1,8 @@
 const axios = require('axios');
-const validate = require('./methods');
+const {
+  buildId,
+  validate,
+} = require('./methods');
 const config = require('../../config');
 const Logger = require('../utils/logger');
 
@@ -20,9 +23,29 @@ const buildURL = (method, params) => {
   return `${url}/${method}?${query}`;
 };
 
+const TOKEN = {};
+
+const lock = (id) => TOKEN[id] = true;
+
+const release = (id) => delete TOKEN[id];
+
+const locked = (id) => {
+  if (TOKEN[id]) {
+    logger.error('locked', { id });
+
+    return true;
+  }
+
+  return false;
+};
+
 const call = (method, params = {}) => {
   return new Promise((resolve, reject) => {
     if (!validate(method, params)) return reject();
+
+    const id = buildId(method, params);
+    if (locked(id)) return reject();
+    lock(id);
 
     axios({
       method: 'get',
@@ -51,7 +74,7 @@ const call = (method, params = {}) => {
       logger.debug('call', { method, data });
 
       resolve(data);
-    }).catch(() => reject());
+    }).catch(() => reject()).finally(() => release(id));
   });
 };
 

--- a/lib/etherpad/methods.js
+++ b/lib/etherpad/methods.js
@@ -23,6 +23,8 @@ const START_REV = 'startRev';
 const END_REV = 'endRev';
 const PUBLIC_STATUS = 'publicStatus';
 
+const DYNAMIC_PARAMS = [ VALID_UNTIL ];
+
 const methods = {
   createGroup: {
     params: {
@@ -314,4 +316,18 @@ const validate = (method, params) => {
   return true;
 };
 
-module.exports = validate;
+const buildId = (method, params) => {
+  let id = method;
+  for (const [key, value] of Object.entries(params)) {
+    if (!DYNAMIC_PARAMS.includes(key)) {
+      id += `&${key}=${encodeURIComponent(value)}`;
+    }
+  }
+
+  return id;
+};
+
+module.exports = {
+  buildId,
+  validate,
+};

--- a/lib/etherpad/methods.test.js
+++ b/lib/etherpad/methods.test.js
@@ -1,4 +1,4 @@
-const validate = require('./methods');
+const { validate } = require('./methods');
 
 test('createGroup method validation', () => {
   expect(validate('createGroup')).toBe(true);


### PR DESCRIPTION
Add an API call control to avoid repeated events to take place while one
of them is being resolved.

Extra over https://github.com/bigbluebutton/bigbluebutton/issues/14757