### PR TITLE
fix(api): paramless lock

### DIFF
--- a/lib/etherpad/methods.js
+++ b/lib/etherpad/methods.js
@@ -316,10 +316,21 @@ const validate = (method, params) => {
   return true;
 };
 
+const getEntries = (params) => Object.entries(params).filter(entry => {
+  const [key, ] = entry;
+
+  return !DYNAMIC_PARAMS.includes(key);
+});
+
 const buildId = (method, params) => {
   let id = method;
-  for (const [key, value] of Object.entries(params)) {
-    if (!DYNAMIC_PARAMS.includes(key)) {
+  const entries = getEntries(params);
+
+  if (entries.length === 0) {
+    // Avoid locking paramless calls
+    id += `&timestamp=${Date.now()}`;
+  } else {
+    for (const [key, value] of entries) {
       id += `&${key}=${encodeURIComponent(value)}`;
     }
   }


### PR DESCRIPTION
Avoid locking API calls that do not contain any parameter such as `createGroup`.

When a meeting is created at BigBlueButton, the Meteor server sends an event requiring
the creation of a pad's group for the `notes` feature. Since `createGroup` does
not contains any parameters it's lock key was built using only the method's signature,
locking any other `createGroup` call within the server.

Included a timestamp for lock's key when the method lacks parameters.

Closes https://github.com/bigbluebutton/bigbluebutton/issues/15025