### PR TITLE
chore: add .nvmrc (set to Node.js 16 LTS)

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/gallium


### PR DESCRIPTION
Creates a .nvmrc file set to Node.js 16 (LTS) to make development
environments clearer/easier to setup.

Relates to #8 