### PR TITLE
refactor: decrease throttle timeout

### DIFF
--- a/config/settings.json.template
+++ b/config/settings.json.template
@@ -11,7 +11,7 @@
       "ttl": 21600000
     },
     "update": {
-      "throttle": 15000
+      "throttle": 3000
     }
   },
   "express": {


### PR DESCRIPTION
Once [#15685](https://github.com/bigbluebutton/bigbluebutton/pull/15685) is merged, the Shared Notes update data, which is sent from the html5-server to user's browser will be reduced, as only the diff will be sent to the user's browser. Thus, I think we can decrease the throttle timeout for publishing the pad content.

This PR is an attempt to address [#15663](https://github.com/bigbluebutton/bigbluebutton/issues/15663).

[#15685](https://github.com/bigbluebutton/bigbluebutton/pull/15685) paved the way in order to decrease the throttle timeout.