### PR TITLE
refactor(database): move models to settings

### DIFF
--- a/config/settings.json.template
+++ b/config/settings.json.template
@@ -42,7 +42,7 @@
         "VIEWER": false
       },
       "capacity": 1
-    },
+    }
   },
   "monitor": {
     "enabled": true,

--- a/config/settings.json.template
+++ b/config/settings.json.template
@@ -31,17 +31,17 @@
       "id": "notes",
       "permission": {
         "MODERATOR": true,
-        "VIEWER": true,
+        "VIEWER": true
       },
-      "capacity": 0,
+      "capacity": 0
     },
     "captions": {
       "id": "captions",
       "permission": {
         "MODERATOR": true,
-        "VIEWER": false,
+        "VIEWER": false
       },
-      "capacity": 1,
+      "capacity": 1
     },
   },
   "monitor": {

--- a/config/settings.json.template
+++ b/config/settings.json.template
@@ -26,6 +26,24 @@
   "log": {
     "level": "info"
   },
+  "models": {
+    "notes": {
+      "id": "notes",
+      "permission": {
+        "MODERATOR": true,
+        "VIEWER": true,
+      },
+      "capacity": 0,
+    },
+    "captions": {
+      "id": "captions",
+      "permission": {
+        "MODERATOR": true,
+        "VIEWER": false,
+      },
+      "capacity": 1,
+    },
+  },
   "monitor": {
     "enabled": true,
     "interval": 3600000

--- a/lib/redis/database.js
+++ b/lib/redis/database.js
@@ -15,24 +15,7 @@ const logger = new Logger('database');
 
 const { etherpad: settings } = config;
 
-const MODELS = {
-  notes: {
-    id: 'notes',
-    permission: {
-      MODERATOR: true,
-      VIEWER: true,
-    },
-    capacity: 0,
-  },
-  captions: {
-    id: 'captions',
-    permission: {
-      MODERATOR: true,
-      VIEWER: false,
-    },
-    capacity: 1,
-  },
-};
+const MODELS = settings.models;
 
 const database = {};
 

--- a/lib/redis/database.js
+++ b/lib/redis/database.js
@@ -13,9 +13,9 @@ const Logger = require('../utils/logger');
 
 const logger = new Logger('database');
 
-const { etherpad: settings } = config;
+const { etherpad: settings, models } = config;
 
-const MODELS = settings.models;
+const MODELS = models;
 
 const database = {};
 


### PR DESCRIPTION
@Arthurk12 and @prlanzarin , would this be enough to cover the feature you are trying to add at your end?

I thought this would be easier to justify over adding something like an extension for the pad models. Besides akka-apps will probably need a couple of changes to cover that too and I don`t think you would like to touch that right now.

(I did not test this solution, by the way and just realized I left the original object commas at the json file. They need to be removed)