### PR TITLE
Prevent proxy lock when used by different pads

### DIFF
--- a/lib/express/proxy.js
+++ b/lib/express/proxy.js
@@ -39,7 +39,7 @@ proxy.on('proxyReq', (proxyReq, req) => {
 const web = (req, res) => {
   const { padId } = req.params;
   const { groupId } = parsePadId(padId);
-  api.call('createAuthor', { name: 'proxy' }).then(response => {
+  api.call('createAuthor', { name: `proxy-${padId}` }).then(response => {
     const authorId = response.authorID;
     logger.trace(ids.USER, 'created', { groupId, authorId });
     api.call('createSession', {


### PR DESCRIPTION
Currently, usage of the export proxy locks Etherpad's API entirely until the request is handled.

At scale, this can becomes problematic under these circumstances:
- multiple recordings processing at the same time may not be able to download the shared notes
- in 2.6, shared notes can automatically be sent back as presentations from breakout rooms once they end

By including the `padId` in the author name, multiple requests from the same pad are still prevented, while allowing other pads from requesting the file.

With this approach, I was able to get 10 simultaneous requests exporting at the same time before getting an `HTTP 429 Too Many Requests` error back with an according `Retry-After` payload.