### PR TITLE
feat(config): settings override

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -1,5 +1,26 @@
-const settings = require('./settings');
+const fs = require('node:fs');
+const _ = require('lodash');
 
-const config = settings;
+const DEFAULT_SETTINGS_FILE_PATH = './settings.json';
+const LOCAL_SETTINGS_FILE_PATH = '/etc/bigbluebutton/bbb-pads.json';
+
+const localSettingsExists = () => {
+	try {
+		fs.accessSync(LOCAL_SETTINGS_FILE_PATH);
+	} catch (err) {
+		return false;
+	}
+	return true;
+};
+
+const SETTINGS = require(DEFAULT_SETTINGS_FILE_PATH);
+
+if (localSettingsExists()) {
+    const LOCAL_SETTINGS = require(LOCAL_SETTINGS_FILE_PATH);
+    _.mergeWith(SETTINGS, LOCAL_SETTINGS, (a, b) => (_.isArray(b) ? b : undefined));
+}
+
+const config = SETTINGS;
 
 module.exports = config;
+


### PR DESCRIPTION
### What does this PR do?

Implements a configuration file override.
Looks for local settings file located in `/etc/bigbluebutton/bbb-pads.json` and if present, merges it with the default one.
Arrays are not merged, but replaced.