### PR TITLE
fix: SharedNotes doesn't work when two users with same Name join at the same time

### DIFF
--- a/lib/etherpad/methods.js
+++ b/lib/etherpad/methods.js
@@ -3,6 +3,7 @@ const Logger = require('../utils/logger');
 const logger = new Logger('methods');
 
 const AUTHOR_ID = 'authorID';
+const AUTHOR_MAPPER = 'authorMapper';
 const GROUP_ID = 'groupID';
 const PAD_ID = 'padID';
 const SESSION_ID = 'sessionID';
@@ -59,6 +60,12 @@ const methods = {
   createAuthor: {
     params: {
       mandatory: [],
+      optional: [AUTHOR_NAME],
+    },
+  },
+  createAuthorIfNotExistsFor: {
+    params: {
+      mandatory: [AUTHOR_MAPPER],
       optional: [AUTHOR_NAME],
     },
   },

--- a/lib/redis/database.js
+++ b/lib/redis/database.js
@@ -406,7 +406,7 @@ const createUser = (meetingId, {
         return reject();
       }
 
-      api.call('createAuthor', { name }).then(response => {
+      api.call('createAuthorIfNotExistsFor', { authorMapper: userId, name }).then(response => {
         const authorId = response.authorID;
         database[meetingId].users[userId] = {
           authorId,


### PR DESCRIPTION
Shared Notes doesn't work properly when two users using the same Name join at the same time.
This error happens mainly during the tests cause it runs several tests simultaneously and using the same Username always.

How to reproduce:

[Screencast from 23-02-2023 11:16:17.webm](https://user-images.githubusercontent.com/5660191/220934579-cc660298-f0e3-4e72-917e-f7c13fc49a57.webm)


Bbb-pads throw this error:
```
bbb-pads[26555]: 2023-02-23T14:10:16.333Z ERROR         [api] locked {"id":"createAuthor&name=User%207461385"}
bbb-pads[26555]: 2023-02-23T14:10:16.333Z ERROR         [database] user creating {"meetingId":"0fc2949494b4ecccafd1af4cd9eba3d73a1af43a-1677161404572","userId":"w_vinhaqmqvzgk"}
bbb-pads[26555]: 2023-02-23T14:10:16.333Z ERROR         [handler] user creating {"meetingId":"0fc2949494b4ecccafd1af4cd9eba3d73a1af43a-1677161404572","body":{"intId":"w_vinhaqmqvzgk","extId":"w_vinhaqmqvzgk","name":"User 7461385","role":"MODERATOR","guest":false,"authed":true,"guestStatus":"ALLOW","emoji":"none","pin":false,"presenter":false,"locked":true,"avatar":"","clientType":"HTML5"}}
```

It happens because currently `bbb-pads` use only the name of the user to create the `lock-id`.

This PR tweak `bbb-pads` to use the Etherpad method `createAuthorIfNotExistsFor` which contains also the param `authorMapper` (that will always be unique per user).
The previous method `createAuthor` has only `name` as parameter and it is the cause of the problem.