### PR TITLE
Changes for Etherpad 1.9.1 upgrade

### DIFF
--- a/lib/redis/handler.js
+++ b/lib/redis/handler.js
@@ -216,13 +216,11 @@ const handlePadUpdated = (header, body) => {
     pad,
   } = body;
 
-  const {
-    atext,
-    id: padId,
-  } = pad;
+  // Fallback to padId if needed
+  const padId = pad.id || pad.padId;
 
   // Clear Etherpad's "\n" insertion
-  const text = atext.text.endsWith('\n') ? atext.text.slice(0, -1) : atext.text;
+  const text = pad.atext.text.endsWith('\n') ? pad.atext.text.slice(0, -1) : pad.atext.text;
 
   database.updatePad(padId, { authorId, rev, changeset, text }).then(() => {
     logger.debug(ids.PAD, 'updated', { padId, authorId, rev, changeset, text });


### PR DESCRIPTION
Uses `pad.padId` instead of `pad.id`, should the latter not be present in the pad update message. See discussion in https://github.com/bigbluebutton/bigbluebutton/pull/18276.