### PR TITLE
Bump bbb-pads to 1.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bbb-pads",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bbb-pads",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "LGPL-3.0",
       "dependencies": {
         "@mconf/bbb-diff": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bbb-pads",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "BigBlueButton's pads manager",
   "engines": {
     "node": ">=16"


### PR DESCRIPTION
Update `bbb-pads` to version 1.5.1 due to major version update of axios: https://github.com/bigbluebutton/bbb-pads/pull/31