### PR TITLE
refactor: Add readOnlyID to PadCreatedEvtMsg

### DIFF
--- a/lib/redis/database.js
+++ b/lib/redis/database.js
@@ -637,7 +637,16 @@ const createPad = (meetingId, groupId, { name }) => {
 
         mapper.createPad(meetingId, groupId, padId);
 
-        sender.send('padCreated', meetingId, { groupId, padId, name });
+        return api.call('getReadOnlyID', {padID: padId});
+      }).then(response => {
+        logger.trace(ids.PAD, 'obtained readOnlyId', { meetingId, groupId, response });
+
+        sender.send('padCreated', meetingId, {
+          groupId,
+          padId,
+          name,
+          readOnlyId: response.readOnlyID || ''
+        });
 
         resolve(database[meetingId].groups[groupId].pads[padId]);
       }).catch(() => {


### PR DESCRIPTION
BBB used to employ Etherpad's read-only view for users who didn't have writing privileges. This functionality was modified by  https://github.com/bigbluebutton/bigbluebutton/pull/13916.

After some tests, I found that `bbb-pads` automatically invalidates a user's session once they lose writing rights. As a result, even if the user tries to restore their previous session, they will no longer have the ability to modify the note.

For the upcoming BBB 2.8 release, I plan to conduct tests utilizing Etherpad's read-only mode. This is because the read-only mode offers a significantly improved user experience.

This particular PR essentially fetches the read-only ID of the pad and transmits it via the `PadCreatedEvtMsg` message. This ID will then be stored in the database and accessible through GraphQL.