### PR TITLE
Send msg containing Full Content alongside Diff for database storage

### DIFF
--- a/config/settings.json.template
+++ b/config/settings.json.template
@@ -11,7 +11,7 @@
       "ttl": 21600000
     },
     "update": {
-      "throttle": 15000
+      "throttle": 5000
     }
   },
   "express": {

--- a/lib/redis/database.js
+++ b/lib/redis/database.js
@@ -261,7 +261,7 @@ const onPadUpdate = (meetingId, groupId, padId, rev) => {
         database[meetingId].groups[groupId].pads[padId].html = html;
         logger.info(ids.PAD, 'content', { meetingId, groupId, padId, rev, ...change });
 
-        sender.send('padContent', meetingId, { groupId, padId, rev, ...change });
+        sender.send('padContent', meetingId, { groupId, padId, rev, html, ...change });
       }
     }).catch(() => logger.error(ids.PAD, 'content', { meetingId, groupId, padId, rev }));
   }

--- a/run-dev.sh
+++ b/run-dev.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+cd "$(dirname "$0")"
+
+cp config/settings.json.template config/settings.json
+sed -i "s/ETHERPAD_API_KEY/\"$(cat /usr/share/etherpad-lite/APIKEY.txt)\"/" config/settings.json
+
+for var in "$@"
+do
+    if [[ $var == --reset ]] ; then
+    	echo "Performing a full reset..."
+      rm -rf node_modules
+    fi
+done
+
+if [ ! -d ./node_modules ] ; then
+	npm install
+fi
+
+sudo systemctl stop bbb-pads
+npm start


### PR DESCRIPTION
Currently, when the text in shared notes is updated, `bbb-pads` sends a message that contains only the changes made (the diff), rather than the entire updated content. This system relies on both the sending and receiving sides understanding how to generate and apply these diffs. Specifically, `bbb-pads` generates the diff, and `bbb-html5 (Meteor)` is responsible for applying this diff to update the content.

However, a new development has arisen: the notes are now going to be stored in a database by `akka-apps`. The problem is that `akka-apps` does not possess the functionality to apply these diffs to the existing content.

To resolve this issue, a proposed modifying `bbb-pads`. Instead of sending only the diff, `bbb-pads` will now send both the diff and the full updated content. With this change, `akka-apps` will not need to patch the content with the diff; it can simply store the full, updated content directly into the database, just as it is received from `bbb-pads`.

So this PR will:
- Change the message `PadContentSysMsg` including the full html content instead of only the diff.
- Reduce default update throttle to 5secs (the read only experience is too bad with 15 secs of delay).
- Include a script `run-dev.sh` following the pattern of the other BBB services

Required by: https://github.com/bigbluebutton/bigbluebutton/pull/19437