### PR TITLE
Fix duplicate lock keys for `createGroup` when creating breakout rooms

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,22 @@ BigBlueButton's pads manager
 
 ## Instructions
 At your BigBlueButton server, clone and install this app:
-```
+```bash
 git clone https://github.com/bigbluebutton/bbb-pads.git
 cd bbb-pads
 npm install
 ```
 Copy the settings' template file and replace `ETHERPAD_API_KEY` with your Etherpad's server API key
-```
+Find the key at `/usr/share/etherpad-lite/APIKEY.txt`
+```bash
 cp config/settings.json.template config/settings.json
 ```
-Run the app:
+Stop the service if it's running:
+```bash
+sudo systemctl stop bbb-pads
 ```
+
+Run the app:
+```bash
 npm start
 ```

--- a/lib/etherpad/api.js
+++ b/lib/etherpad/api.js
@@ -57,9 +57,13 @@ const call = (method, params = {}) => {
     if (locked(id)) return reject();
     lock(id);
 
+    const url = buildURL(method, params);
+
+    logger.debug(`API request: ${url}`);
+
     axios({
       method: 'get',
-      url: buildURL(method, params),
+      url,
       responseType: 'json',
     }).then((response) => {
       const { status } = response;

--- a/lib/etherpad/methods.js
+++ b/lib/etherpad/methods.js
@@ -5,6 +5,7 @@ const logger = new Logger('methods');
 const AUTHOR_ID = 'authorID';
 const AUTHOR_MAPPER = 'authorMapper';
 const GROUP_ID = 'groupID';
+const GROUP_MAPPER = 'groupMapper';
 const PAD_ID = 'padID';
 const SESSION_ID = 'sessionID';
 const SOURCE_ID = 'sourceID';
@@ -30,6 +31,12 @@ const methods = {
   createGroup: {
     params: {
       mandatory: [],
+      optional: [],
+    },
+  },
+  createGroupIfNotExistsFor: {
+    params: {
+      mandatory: [GROUP_MAPPER],
       optional: [],
     },
   },

--- a/lib/redis/database.js
+++ b/lib/redis/database.js
@@ -554,7 +554,7 @@ const createGroup = (meetingId, {
         return reject();
       }
 
-      api.call('createGroup').then(response => {
+      api.call('createGroupIfNotExistsFor', {groupMapper: `${meetingId}-${externalId}-${model}`}).then(response => {
         const groupId = response.groupID;
         database[meetingId].groups[groupId] = {
           externalId,


### PR DESCRIPTION
Previously, the `createGroup` handler used a lock with the timestamp as the key, e.g., `createGroup&timestamp=1756320778328`. The issue was that when creating breakout rooms, two or more rooms could occasionally receive the exact same timestamp, resulting in identical lock keys. This led to the error reported at https://github.com/bigbluebutton/bigbluebutton/issues/23805

To address this, `bbb-pads` now calls `createGroupIfNotExistsFor` instead of `createGroup`. Unlike the old approach, `createGroupIfNotExistsFor` receives an unique ID (`groupMapper`) that now will include the `meetingId`, ensuring each room gets a distinct lock key. With this change, every room will generate a different API request:

<img width="3685" height="1206" alt="image" src="https://github.com/user-attachments/assets/3cb3bf34-0265-49f8-92f3-69e2ac2a3812" />


