### PR TITLE
[Docker] Overwrite config not appending

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,7 @@ cat config/settings.json.template | \
   sed "s/ETHERPAD_API_KEY/\"$ETHERPAD_API_KEY\"/g" | \
   jq '.etherpad.host = "etherpad"' | \
   jq '.express.host = "0.0.0.0"' | \
-  jq '.redis.host = "redis"' >> $TARGET
+  jq '.redis.host = "redis"' > $TARGET
 
 
 cd /app


### PR DESCRIPTION
Fixes container restart. After the second restart the json exists twice, causing a reboot loop where the config file grows in length